### PR TITLE
Simplify and document the setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Server with endpoint to return an rss of movies showing today in the list of giv
 
 * Start a python virtual environment.
 * Install requirements: `pip install -r requirements/prod.txt`
-* Copy the `prod.env.template` file to `prod.env` and enter the authorization keys needed to access the allocine api.
-    - Alternatively, set the following environment variables:
+* Follow the steps in [SETUP.md](SETUP.md) to get an authorization token and to know the ids of theaters you want.
+* Copy the `prod.env.template` file to `prod.env` and enter the authorization token needed to access the allocine api.
+    - Alternatively, set the following environment variable:
         - `AUTHORIZATION`
-        - `AC_AUTH_TOKEN`
 * Run the server:
     ```
     python -m cinetodayrss.main
@@ -25,17 +25,17 @@ Server with endpoint to return an rss of movies showing today in the list of giv
   - Alternatively: Build the docker image: `docker build -t cine-today-rss`.
 * Run the server passing in your authorization keys as environment variables:
     ```
-    docker run --env authorization="..." --env ac_auth_token="..." --detach --publish 8000:8000 ghcr.io/caarmen/cine-today-rss
+    docker run --env authorization="..." --detach --publish 8000:8000 ghcr.io/caarmen/cine-today-rss
     ```
 ☝️ Note, by default, the docker container runs in the UTC timezone. Therefore, it will query the allocine api providing datetimes in utc. This may not be the desired behavior. To make the docker container run in a specific timezone, specify the `TZ` environment variable. For example, to specify a Paris timezone, use `--env TZ=Europe/Paris`:
 ```
-docker run --env TZ=Europe/Paris --env authorization="..." --env ac_auth_token="..." --detach --publish 8000:8000 ghcr.io/caarmen/cine-today-rss
+docker run --env TZ=Europe/Paris --env authorization="..." --detach --publish 8000:8000 ghcr.io/caarmen/cine-today-rss
 ```
 
 ### Query the server
 
 Query the endpoint for some theater ids:
     ```
-    curl "http://localhost:8000/moviesrss?theater_ids=VGhlYXRlcjpQMDAwNQ==&theater_ids=VGhlYXRlcjpQMDAzNg=="
+    curl "http://localhost:8000/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==&theater_ids=VGhlYXRlcjpQNTc1Ng=="
     ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,59 @@
+# Cine-today-rss setup
+
+## What you need
+To use this application, you need:
+* An authorization token
+* One or more theater ids
+
+## How to get it
+
+#### First, some manual actions:
+
+* Log into the allocine.fr website in a browser.
+* Add one or more cinemas to your list of cinemas.
+* Navigate to the page with the movies showing in your list of cinemas: https://mon.allocine.fr/mes-cinemas/
+
+
+#### Inspect network requests in the browser
+* Open the developer tools of the browser, and click the "network" tab.
+* In the text filter, type "graph" to limit the results.
+* Reload the page in the browser.
+* You'll see three network requests appeaer in the developer tools.
+  - The first one is a request for a `getUser` query. You can ignore this one for now.
+  - The second one is a request for a `getTheaters` query.  This is the one we'll inspect.
+* View the *request headers* for this request.
+  - The authorization token is in the `auhorization: Bearer ey.......CQg` header. This token (not including `Bearer: `) is what you should set for your `authorization` environment variable.
+* View the *response* for this query.
+  - You'll see something like:
+    ```json
+    {
+    "data": {
+        "me": {
+            "user": {
+                "id": "<some id>",
+                "social": {
+                    "theaters": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "id": "VGhlYXRlcjpDMDE1OQ==",
+                                    "internalId": "C0159",
+                                    "name": "UGC Cin\u00e9 Cit\u00e9 Les Halles",
+                                    "theaterCircuits": {
+                                        "poster": {
+                                            "path": "\/company\/19\/08\/12\/18\/40\/2992720.jpg",
+                                            "__typename": "InternalImage"
+                                        },
+                                        "__typename": "Company"
+                                    },
+                                    "poster": null,
+                                    "location": {
+                                        "city": "Paris",
+                                        "zip": "75001",
+                                        "address": "7, place de la Rotonde",
+
+    ```
+    - Note the cinema id in this example `VGhlYXRlcjpDMDE1OQ=="`. Find all the ids like this. These are what you have to provide for the `theater_ids=` query params to this cine-today-rss server.
+
+
+

--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -17,7 +17,7 @@ from cinetodayrss.settings import settings
 
 _cache = {}
 CACHE_CLEAR_INTERVAL_S = 24 * 60 * 60
-ALLOCINE_GRAPHQL_URL = "https://graph.allocine.fr/v1/mobile"
+ALLOCINE_GRAPHQL_URL = "https://graph.allocine.fr/v1/public"
 ALLOCINE_FILM_URL_TEMPLATE = "https://www.allocine.fr/film/fichefilm_gen_cfilm={}.html"
 
 
@@ -118,7 +118,6 @@ async def _get_movies_for_theater(theater_id: str) -> List[Movie]:
             url=ALLOCINE_GRAPHQL_URL,
             headers={
                 "Authorization": f"Bearer {settings.authorization}",
-                "AC-Auth-Token": settings.ac_auth_token,
             },
         ),
         fetch_schema_from_transport=True,

--- a/cinetodayrss/settings.py
+++ b/cinetodayrss/settings.py
@@ -12,7 +12,6 @@ class Settings(BaseSettings):
     """
 
     authorization: str = ""
-    ac_auth_token: str = ""
 
 
 settings = Settings(_env_file="prod.env")

--- a/prod.env.template
+++ b/prod.env.template
@@ -1,2 +1,1 @@
 authorization=""
-ac_auth_token=""

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -16,7 +16,6 @@ from cinetodayrss.service import movieshowtimes
 from cinetodayrss.service.movieshowtimes import Movie
 from cinetodayrss.settings import settings
 
-settings.ac_auth_token = "some token"
 settings.authorization = "some authorization"
 client = TestClient(app)
 
@@ -50,7 +49,7 @@ def test_rss_feed(graphql_response_factory):
         ]
     ):
         response = client.get(
-            "/moviesrss?theater_ids=VGhlYXRlcjpQMDAwNQ==&theater_ids=VGhlYXRlcjpQMDAzNg=="
+            "/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==&theater_ids=VGhlYXRlcjpQNTc1Ng=="
         )
         assert response.status_code == 200
         rss_doc_root = ET.fromstring(response.content)
@@ -92,7 +91,7 @@ def test_date_cache(graphql_response_factory):
             graphql_response_factory([Movie(id="111", title="Une comédie")]),
         ]
     ):
-        response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpQMDAwNQ==")
+        response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==")
         assert response.status_code == 200
         rss_doc_root = ET.fromstring(response.content)
         items = rss_doc_root.find("channel").findall("item")
@@ -113,7 +112,7 @@ def test_date_cache(graphql_response_factory):
             graphql_response_factory([Movie(id="111", title="Une comédie")]),
         ]
     ):
-        response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpQMDAwNQ==")
+        response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==")
         assert response.status_code == 200
         rss_doc_root = ET.fromstring(response.content)
         items = rss_doc_root.find("channel").findall("item")
@@ -139,7 +138,7 @@ def test_remove_duplicates(graphql_response_factory):
         ]
     ):
         response = client.get(
-            "/moviesrss?theater_ids=VGhlYXRlcjpQMDAwNQ==&theater_ids=VGhlYXRlcjpQMDAzNg=="
+            "/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==&theater_ids=VGhlYXRlcjpQNTc1Ng=="
         )
         assert response.status_code == 200
         rss_doc_root = ET.fromstring(response.content)


### PR DESCRIPTION
Now: just require one authorization token, not two. The path of the url changes from `/mobile` to `/public`.

Document how to get this token, and how to get the theater ids. 

☝️Note that the single token obtained with these setups is associated with an allocine account. The previous system with the `/mobile` path and two tokens was anonymous. I don't know how to obtain the anonymous token.

It appears the duration of both the anonymous and user-associated tokens is one year.

Also changed some theater ids in the examples to be consistent with the setup instructions.