### PR TITLE
Remove the dependency to pytz.

### DIFF
--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -4,13 +4,12 @@ Implementation of the movieshowtimes endpoint
 
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from email.utils import formatdate
 from threading import Timer
 from typing import Any, Dict, List, Set
 
 import gql
-import pytz
 from gql.client import Client
 from gql.transport.aiohttp import AIOHTTPTransport
 
@@ -147,13 +146,13 @@ async def get_movies_rss(theater_ids: List[Movie], feed_url: str) -> str:
 def _get_date(movie_id: int) -> str:
     movie_date = _cache.get(movie_id)
     if not movie_date:
-        movie_date = datetime.now(tz=pytz.UTC)
+        movie_date = datetime.now(tz=timezone.utc)
         _cache[movie_id] = movie_date
     return formatdate(movie_date.timestamp())
 
 
 def _purge_cache():
-    date_limit = datetime.now(tz=pytz.UTC) - timedelta(days=90)
+    date_limit = datetime.now(tz=timezone.utc) - timedelta(days=90)
     old_movie_ids = [
         movie_id for (movie_id, date) in _cache.items() if date < date_limit
     ]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,5 +2,4 @@ aiohttp==3.10.5
 fastapi==0.112.2
 gql==3.5.0
 pydantic==1.10.18
-pytz==2024.1
 uvicorn[standard]==0.30.6

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -4,12 +4,11 @@ Unit tests for cine today rss
 
 import xml.etree.ElementTree as ET
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from typing import Dict, Any, List
 from unittest.mock import patch, AsyncMock
 
-import pytz
 from fastapi.testclient import TestClient
 
 from cinetodayrss.main import app
@@ -86,7 +85,7 @@ def test_date_cache(graphql_response_factory):
     """
     # We can access this just for tests
     # pylint: disable=protected-access
-    movieshowtimes._cache[111] = datetime(1995, 12, 31, 22, 10, 00, tzinfo=pytz.utc)
+    movieshowtimes._cache[111] = datetime(1995, 12, 31, 22, 10, 00, tzinfo=timezone.utc)
     with _mock_client(
         payloads=[
             graphql_response_factory([Movie(id="111", title="Une comédie")]),


### PR DESCRIPTION
Use timezone from the builtin datetime module, instaed.