### PR TITLE
Update the version of pydantic.

### DIFF
--- a/cinetodayrss/settings.py
+++ b/cinetodayrss/settings.py
@@ -2,7 +2,7 @@
 Settings module
 """
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 # pylint: disable=too-few-public-methods

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 aiohttp==3.10.5
 fastapi==0.112.2
 gql==3.5.0
-pydantic==1.10.18
+pydantic-settings==2.4.0
 uvicorn[standard]==0.30.6


### PR DESCRIPTION
Follow the migration guide: https://docs.pydantic.dev/latest/migration/#install-pydantic-v2

Replace the dependency on pydantic with a dependency on pydantic-settings.