### PR TITLE
Replace the memory cache with a disk-based cache.

### DIFF
--- a/cinetodayrss/dependencies.py
+++ b/cinetodayrss/dependencies.py
@@ -1,0 +1,24 @@
+"""
+Provides dependencies for FastAPI dependency injection
+"""
+
+from typing import Annotated
+
+from fastapi import Depends
+from cinetodayrss.service.cache import MovieCache
+from cinetodayrss.settings import settings
+
+
+def get_cache_dir() -> str:
+    """
+    :return: the location of the folder containing the movie cache.
+    """
+
+    return settings.cache_dir
+
+
+def get_movie_cache(cache_dir2: Annotated[str, Depends(get_cache_dir)]) -> MovieCache:
+    """
+    :return: the MovieCache.
+    """
+    return MovieCache(cache_dir=cache_dir2)

--- a/cinetodayrss/routers/movieshowtimes.py
+++ b/cinetodayrss/routers/movieshowtimes.py
@@ -2,8 +2,10 @@
 Router to list movies with their showtimes
 """
 
-from typing import List
-from fastapi import APIRouter, Query, Request, Response
+from typing import Annotated, List
+from fastapi import APIRouter, Depends, Query, Request, Response
+from cinetodayrss.dependencies import get_movie_cache
+from cinetodayrss.service.cache import MovieCache
 from cinetodayrss.service.movieshowtimes import get_movies_rss
 
 
@@ -20,12 +22,14 @@ router = APIRouter()
     },
 )
 async def movies_rss(
+    movie_cache: Annotated[MovieCache, Depends(get_movie_cache)],
     request: Request,
     theater_ids: List[str] = Query(default=[]),
 ):
     content = await get_movies_rss(
         theater_ids,
         feed_url=str(request.url),
+        movie_cache=movie_cache,
     )
     return Response(
         content=content,

--- a/cinetodayrss/routers/movieshowtimes.py
+++ b/cinetodayrss/routers/movieshowtimes.py
@@ -4,11 +4,11 @@ Router to list movies with their showtimes
 
 from typing import List
 from fastapi import APIRouter, Query, Request, Response
-from cinetodayrss.service.movieshowtimes import get_movies_rss, schedule_purge_cache
+from cinetodayrss.service.movieshowtimes import get_movies_rss, _cache
 
 
 router = APIRouter()
-schedule_purge_cache()
+_cache.schedule_purge_cache()
 
 
 @router.get(

--- a/cinetodayrss/routers/movieshowtimes.py
+++ b/cinetodayrss/routers/movieshowtimes.py
@@ -24,7 +24,10 @@ async def movies_rss(
     request: Request,
     theater_ids: List[str] = Query(default=[]),
 ):
-    content = await get_movies_rss(theater_ids, feed_url=str(request.url))
+    content = await get_movies_rss(
+        theater_ids,
+        feed_url=str(request.url),
+    )
     return Response(
         content=content,
         media_type="application/rss+xml; charset=utf-8",

--- a/cinetodayrss/routers/movieshowtimes.py
+++ b/cinetodayrss/routers/movieshowtimes.py
@@ -4,11 +4,10 @@ Router to list movies with their showtimes
 
 from typing import List
 from fastapi import APIRouter, Query, Request, Response
-from cinetodayrss.service.movieshowtimes import get_movies_rss, _cache
+from cinetodayrss.service.movieshowtimes import get_movies_rss
 
 
 router = APIRouter()
-_cache.schedule_purge_cache()
 
 
 @router.get(

--- a/cinetodayrss/service/cache.py
+++ b/cinetodayrss/service/cache.py
@@ -3,9 +3,10 @@ Cache of movie data
 """
 
 import datetime as dt
-from threading import Timer
+from diskcache import Cache
 
-_CACHE_CLEAR_INTERVAL_S = 24 * 60 * 60
+
+_CACHE_TIMEOUT_S = 90 * 24 * 60 * 60  # 90 days in seconds
 
 
 class MovieCache:
@@ -13,8 +14,8 @@ class MovieCache:
     Cache of movie data
     """
 
-    def __init__(self):
-        self._cache: dict[int, dt.datetime] = {}
+    def __init__(self, cache_dir):
+        self._cache_dir = cache_dir
 
     def get_date(
         self,
@@ -23,35 +24,25 @@ class MovieCache:
         """
         Get the date this movie was last recorded.
         """
-        movie_date: dt.datetime | None = self._cache.get(movie_id)
-        if not movie_date:
-            movie_date = dt.datetime.now(tz=dt.timezone.utc)
-            self._cache[movie_id] = movie_date
+        with Cache(
+            directory=self._cache_dir,
+        ) as cache:
+            movie_date: dt.datetime | None = cache.get(str(movie_id))
+            if not movie_date:
+                movie_date = dt.datetime.now(tz=dt.timezone.utc)
+                cache.set(
+                    key=str(movie_id),
+                    value=movie_date,
+                    expire=_CACHE_TIMEOUT_S,
+                )
 
         return movie_date
-
-    def purge_old_movies(self):
-        """
-        Remove movies from the cache which were recorded "a long time ago".
-        """
-        date_limit = dt.datetime.now(tz=dt.timezone.utc) - dt.timedelta(days=90)
-        old_movie_ids = [
-            movie_id for (movie_id, date) in self._cache.items() if date < date_limit
-        ]
-        for old_movie_id in old_movie_ids:
-            self._cache.pop(old_movie_id, None)
-
-    def schedule_purge_cache(self):
-        """
-        Periodically delete old movies from the cache
-        """
-        self.purge_old_movies()
-        timer = Timer(_CACHE_CLEAR_INTERVAL_S, self.schedule_purge_cache, self)
-        timer.daemon = True
-        timer.start()
 
     def clear(self):
         """
         Remove all movies from the cache.
         """
-        self._cache.clear()
+        with Cache(
+            directory=self._cache_dir,
+        ) as cache:
+            cache.clear()

--- a/cinetodayrss/service/cache.py
+++ b/cinetodayrss/service/cache.py
@@ -3,6 +3,9 @@ Cache of movie data
 """
 
 import datetime as dt
+from threading import Timer
+
+_CACHE_CLEAR_INTERVAL_S = 24 * 60 * 60
 
 
 class MovieCache:
@@ -37,6 +40,15 @@ class MovieCache:
         ]
         for old_movie_id in old_movie_ids:
             self._cache.pop(old_movie_id, None)
+
+    def schedule_purge_cache(self):
+        """
+        Periodically delete old movies from the cache
+        """
+        self.purge_old_movies()
+        timer = Timer(_CACHE_CLEAR_INTERVAL_S, self.schedule_purge_cache, self)
+        timer.daemon = True
+        timer.start()
 
     def clear(self):
         """

--- a/cinetodayrss/service/cache.py
+++ b/cinetodayrss/service/cache.py
@@ -1,0 +1,45 @@
+"""
+Cache of movie data
+"""
+
+import datetime as dt
+
+
+class MovieCache:
+    """
+    Cache of movie data
+    """
+
+    def __init__(self):
+        self._cache: dict[int, dt.datetime] = {}
+
+    def get_date(
+        self,
+        movie_id: int,
+    ) -> dt.datetime:
+        """
+        Get the date this movie was last recorded.
+        """
+        movie_date: dt.datetime | None = self._cache.get(movie_id)
+        if not movie_date:
+            movie_date = dt.datetime.now(tz=dt.timezone.utc)
+            self._cache[movie_id] = movie_date
+
+        return movie_date
+
+    def purge_old_movies(self):
+        """
+        Remove movies from the cache which were recorded "a long time ago".
+        """
+        date_limit = dt.datetime.now(tz=dt.timezone.utc) - dt.timedelta(days=90)
+        old_movie_ids = [
+            movie_id for (movie_id, date) in self._cache.items() if date < date_limit
+        ]
+        for old_movie_id in old_movie_ids:
+            self._cache.pop(old_movie_id, None)
+
+    def clear(self):
+        """
+        Remove all movies from the cache.
+        """
+        self._cache.clear()

--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -75,23 +75,18 @@ def _to_rss(
     atom_link.set("href", feed_url)
     atom_link.set("rel", "self")
     atom_link.set("type", "application/rss+xml")
-    channel_title = ET.SubElement(channel, "title")
-    channel_title.text = "Films dans vos cinémas aujourd'hui"
-    channel_link = ET.SubElement(channel, "link")
-    channel_link.text = "https://www.allocine.fr/"
-    description = ET.SubElement(channel, "description")
+    ET.SubElement(channel, "title").text = "Films dans vos cinémas aujourd'hui"
+    ET.SubElement(channel, "link").text = "https://www.allocine.fr/"
     today_date_str = date.today().isoformat()
-    description.text = f"Films dans vos cinémas aujourd'hui {today_date_str}"
+    ET.SubElement(channel, "description").text = (
+        f"Films dans vos cinémas aujourd'hui {today_date_str}"
+    )
     for movie in movies:
         item = ET.SubElement(channel, "item")
-        item_title = ET.SubElement(item, "title")
-        item_title.text = movie.title
-        item_link = ET.SubElement(item, "link")
-        item_link.text = movie.url
-        item_guid = ET.SubElement(item, "guid")
-        item_guid.text = movie.url
-        item_pub_date = ET.SubElement(item, "pubDate")
-        item_pub_date.text = _get_date(
+        ET.SubElement(item, "title").text = movie.title
+        ET.SubElement(item, "link").text = movie.url
+        ET.SubElement(item, "guid").text = movie.url
+        ET.SubElement(item, "pubDate").text = _get_date(
             movie.id,
         )
     ET.indent(rss, space="    ")

--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -6,7 +6,6 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime, date
 from email.utils import formatdate
-from threading import Timer
 from typing import Any, Dict, List, Set
 
 import gql
@@ -17,7 +16,6 @@ from cinetodayrss.service.cache import MovieCache
 from cinetodayrss.settings import settings
 
 _cache = MovieCache()
-CACHE_CLEAR_INTERVAL_S = 24 * 60 * 60
 ALLOCINE_GRAPHQL_URL = "https://graph.allocine.fr/v1/public"
 ALLOCINE_FILM_URL_TEMPLATE = "https://www.allocine.fr/film/fichefilm_gen_cfilm={}.html"
 
@@ -155,13 +153,3 @@ def _get_date(
 ) -> str:
     movie_date = _cache.get_date(movie_id)
     return formatdate(movie_date.timestamp())
-
-
-def schedule_purge_cache():
-    """
-    Periodically delete old movies from the cache
-    """
-    _cache.purge_old_movies()
-    timer = Timer(CACHE_CLEAR_INTERVAL_S, schedule_purge_cache)
-    timer.daemon = True
-    timer.start()

--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -63,7 +63,10 @@ query MovieWithShowtimesList($theaterId: String!, $from: DateTime!, $to: DateTim
 )
 
 
-def _to_rss(movies: List[Movie], feed_url: str) -> str:
+def _to_rss(
+    movies: List[Movie],
+    feed_url: str,
+) -> str:
     rss = ET.Element("rss")
     rss.set("version", "2.0")
     rss.set("xmlns:atom", "http://www.w3.org/2005/Atom")
@@ -88,7 +91,9 @@ def _to_rss(movies: List[Movie], feed_url: str) -> str:
         item_guid = ET.SubElement(item, "guid")
         item_guid.text = movie.url
         item_pub_date = ET.SubElement(item, "pubDate")
-        item_pub_date.text = _get_date(movie.id)
+        item_pub_date.text = _get_date(
+            movie.id,
+        )
     ET.indent(rss, space="    ")
     return ET.tostring(rss, xml_declaration=True, encoding="utf-8")
 
@@ -128,7 +133,10 @@ async def _get_movies_for_theater(theater_id: str) -> List[Movie]:
         return _response_to_movies(response)
 
 
-async def get_movies_rss(theater_ids: List[Movie], feed_url: str) -> str:
+async def get_movies_rss(
+    theater_ids: List[Movie],
+    feed_url: str,
+) -> str:
     """
     Get the rss feed for the movies
     """
@@ -139,11 +147,16 @@ async def get_movies_rss(theater_ids: List[Movie], feed_url: str) -> str:
 
     sorted_movies = sorted(movies, key=lambda movie: movie.title)
 
-    rss = _to_rss(sorted_movies, feed_url=feed_url)
+    rss = _to_rss(
+        sorted_movies,
+        feed_url=feed_url,
+    )
     return rss
 
 
-def _get_date(movie_id: int) -> str:
+def _get_date(
+    movie_id: int,
+) -> str:
     movie_date = _cache.get(movie_id)
     if not movie_date:
         movie_date = datetime.now(tz=timezone.utc)

--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -15,7 +15,7 @@ from gql.transport.aiohttp import AIOHTTPTransport
 from cinetodayrss.service.cache import MovieCache
 from cinetodayrss.settings import settings
 
-_cache = MovieCache()
+_cache = MovieCache(settings.cache_dir)
 ALLOCINE_GRAPHQL_URL = "https://graph.allocine.fr/v1/public"
 ALLOCINE_FILM_URL_TEMPLATE = "https://www.allocine.fr/film/fichefilm_gen_cfilm={}.html"
 

--- a/cinetodayrss/settings.py
+++ b/cinetodayrss/settings.py
@@ -2,6 +2,7 @@
 Settings module
 """
 
+from pathlib import Path
 from pydantic_settings import BaseSettings
 
 
@@ -12,6 +13,7 @@ class Settings(BaseSettings):
     """
 
     authorization: str = ""
+    cache_dir: Path = Path("/tmp/cine-today-rss-cache/")
 
 
 settings = Settings(_env_file="prod.env")

--- a/prod.env.template
+++ b/prod.env.template
@@ -1,1 +1,2 @@
 authorization=""
+cache_dir=/tmp/cine-today-rss-cache/

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,5 @@
 aiohttp==3.10.5
+diskcache==5.6.3
 fastapi==0.112.2
 gql==3.5.0
 pydantic-settings==2.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 -r dev.txt
 coverage==7.6.1
+freezegun==1.5.1
 pytest==8.3.2
 pytest-cov==5.0.0
 requests==2.32.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,18 @@ from typing import Dict, Any, List
 
 import pytest
 
+from cinetodayrss.service import movieshowtimes
 from cinetodayrss.service.movieshowtimes import Movie
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """
+    Clear the cache at the beginning and end of each test.
+    """
+    movieshowtimes.schedule_purge_cache()
+    yield
+    movieshowtimes.schedule_purge_cache()
 
 
 @pytest.fixture(name="graphql_response_factory")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,9 @@ def clear_cache():
     """
     Clear the cache at the beginning and end of each test.
     """
-    movieshowtimes.schedule_purge_cache()
+    movieshowtimes._cache.schedule_purge_cache()
     yield
-    movieshowtimes.schedule_purge_cache()
+    movieshowtimes._cache.schedule_purge_cache()
 
 
 @pytest.fixture(name="graphql_response_factory")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,21 +2,22 @@
 Test fixtures
 """
 
+from pathlib import Path
 from typing import Dict, Any, List
 
 import pytest
 
-from cinetodayrss.service.movieshowtimes import Movie, _cache
+from cinetodayrss.dependencies import get_cache_dir
+from cinetodayrss.main import app
+from cinetodayrss.service.movieshowtimes import Movie
 
 
 @pytest.fixture(autouse=True)
-def clear_cache():
+def override_cache_dir(tmp_path: Path):
     """
-    Clear the cache at the beginning and end of each test.
+    Override the cache location for tests.
     """
-    _cache.clear()
-    yield
-    _cache.clear()
+    app.dependency_overrides[get_cache_dir] = lambda: str(tmp_path)
 
 
 @pytest.fixture(name="graphql_response_factory")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,7 @@ from typing import Dict, Any, List
 
 import pytest
 
-from cinetodayrss.service import movieshowtimes
-from cinetodayrss.service.movieshowtimes import Movie
+from cinetodayrss.service.movieshowtimes import Movie, _cache
 
 
 @pytest.fixture(autouse=True)
@@ -15,9 +14,9 @@ def clear_cache():
     """
     Clear the cache at the beginning and end of each test.
     """
-    movieshowtimes._cache.schedule_purge_cache()
+    _cache.clear()
     yield
-    movieshowtimes._cache.schedule_purge_cache()
+    _cache.clear()
 
 
 @pytest.fixture(name="graphql_response_factory")

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -21,13 +21,6 @@ settings.authorization = "some authorization"
 client = TestClient(app)
 
 
-def teardown_function():
-    """
-    Clean up state after each test
-    """
-    movieshowtimes.schedule_purge_cache()
-
-
 @contextmanager
 def _mock_client(payloads: List[Dict[str, Any]]):
     with patch("cinetodayrss.service.movieshowtimes.Client") as mock_client:

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -99,7 +99,7 @@ def test_date_cache(graphql_response_factory):
         assert pub_date.second == 0
 
         frozen_date.move_to(now)
-        movieshowtimes.schedule_purge_cache()
+        movieshowtimes._cache.schedule_purge_cache()
         with _mock_client(
             payloads=[
                 graphql_response_factory([Movie(id="111", title="Une comédie")]),

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -10,6 +10,7 @@ from typing import Dict, Any, List
 from unittest.mock import patch, AsyncMock
 
 from fastapi.testclient import TestClient
+from freezegun import freeze_time
 
 from cinetodayrss.main import app
 from cinetodayrss.service import movieshowtimes
@@ -83,10 +84,8 @@ def test_date_cache(graphql_response_factory):
     """
     Verify that we use the dates from the cache
     """
-    # We can access this just for tests
-    # pylint: disable=protected-access
-    movieshowtimes._cache[111] = datetime(1995, 12, 31, 22, 10, 00, tzinfo=timezone.utc)
-    with _mock_client(
+    now = datetime.now(tz=timezone.utc)
+    with freeze_time("1995-12-31 22:10:00") as frozen_date, _mock_client(
         payloads=[
             graphql_response_factory([Movie(id="111", title="Une comédie")]),
         ]
@@ -106,21 +105,22 @@ def test_date_cache(graphql_response_factory):
         assert pub_date.minute == 10
         assert pub_date.second == 0
 
-    movieshowtimes.schedule_purge_cache()
-    with _mock_client(
-        payloads=[
-            graphql_response_factory([Movie(id="111", title="Une comédie")]),
-        ]
-    ):
-        response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==")
-        assert response.status_code == 200
-        rss_doc_root = ET.fromstring(response.content)
-        items = rss_doc_root.find("channel").findall("item")
-        assert len(items) == 1
-        item = items.pop(0)
-        pub_date_text = item.find("pubDate").text
-        pub_date = parsedate_to_datetime(pub_date_text)
-        assert pub_date.year != 1995
+        frozen_date.move_to(now)
+        movieshowtimes.schedule_purge_cache()
+        with _mock_client(
+            payloads=[
+                graphql_response_factory([Movie(id="111", title="Une comédie")]),
+            ]
+        ):
+            response = client.get("/moviesrss?theater_ids=VGhlYXRlcjpDMDE1OQ==")
+            assert response.status_code == 200
+            rss_doc_root = ET.fromstring(response.content)
+            items = rss_doc_root.find("channel").findall("item")
+            assert len(items) == 1
+            item = items.pop(0)
+            pub_date_text = item.find("pubDate").text
+            pub_date = parsedate_to_datetime(pub_date_text)
+            assert pub_date.year != 1995
 
 
 def test_remove_duplicates(graphql_response_factory):

--- a/tests/test_cinetodayrss.py
+++ b/tests/test_cinetodayrss.py
@@ -99,7 +99,7 @@ def test_date_cache(graphql_response_factory):
         assert pub_date.second == 0
 
         frozen_date.move_to(now)
-        movieshowtimes._cache.schedule_purge_cache()
+
         with _mock_client(
             payloads=[
                 graphql_response_factory([Movie(id="111", title="Une comédie")]),


### PR DESCRIPTION
Refactoring preparation:
* Reformat some function signatures and method calls, to ease the diff in future commits.
* Reduce the number of local variables in `service.movieshowtimes._to_rss()`.
* Use FreezeGun in tests, to mock an old cache entry.
* Move the `teardown_function()` to an autouse test fixture (more common practice in purest).
* Move cache logic into a dedicated module and class.


Behaviour changes:
* Replace the memory movies cache with a disk cache. Use the diskcache package, which uses sqlite3 for the backend.
* Use dependency injection to inject the cache, so we can avoid accessing protected fields, and use a temporary test folder for the cache location.