### PR TITLE
Set`fetch_schema_from_transport=False`.

### DIFF
--- a/cinetodayrss/service/movieshowtimes.py
+++ b/cinetodayrss/service/movieshowtimes.py
@@ -120,7 +120,7 @@ async def _get_movies_for_theater(theater_id: str) -> List[Movie]:
                 "Authorization": f"Bearer {settings.authorization}",
             },
         ),
-        fetch_schema_from_transport=True,
+        fetch_schema_from_transport=False,
         serialize_variables=True,
         parse_results=True,
     ) as client:


### PR DESCRIPTION
This attribute is documented here: https://gql.readthedocs.io/en/stable/usage/validation.html#using-introspection

If set to `True`, then the `Client` will download the schema, so it can "_validate the queries locally before sending them to the backend_".

The allocine server only supports 12 nested levels in an introspection query.

We were getting this error when setting the value to True:

```
  File "/path/to/cine-today-rss/cinetodayrss/routers/movieshowtimes.py", line 29, in movies_rss
    content = await get_movies_rss(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/cine-today-rss/cinetodayrss/service/movieshowtimes.py", line 141, in get_movies_rss
    movies_for_theater = await _get_movies_for_theater(theater_id=theater_id)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/cine-today-rss/cinetodayrss/service/movieshowtimes.py", line 116, in _get_movies_for_theater
    async with Client(
  File "/Users/jdoe/.pyenv/versions/cine-today-rss/lib/python3.12/site-packages/gql/client.py", line 814, in __aenter__
    return await self.connect_async()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jdoe/.pyenv/versions/cine-today-rss/lib/python3.12/site-packages/gql/client.py", line 795, in connect_async
    await self.session.fetch_schema()
  File "/Users/jdoe/.pyenv/versions/cine-today-rss/lib/python3.12/site-packages/gql/client.py", line 1663, in fetch_schema
    self.client._build_schema_from_introspection(execution_result)
  File "/Users/jdoe/.pyenv/versions/cine-today-rss/lib/python3.12/site-packages/gql/client.py", line 179, in _build_schema_from_introspection
    raise TransportQueryError(
gql.transport.exceptions.TransportQueryError: Error while fetching schema: {'message': 'Max query depth should be 12 but got 13.', 'extensions': {'category': 'graphql'}}
If you don't need the schema, you can try with: "fetch_schema_from_transport=False"
```

This started to fail today, because, in the graphql-core package, the number of levels in the introspection query increased by two, in this commit: https://github.com/graphql-python/graphql-core/commit/3d8d36acfe10a243d85e4f0c75ae0f4a59be2ee6

We do not have a direct dependency on graphql-core. We have a pinned dependency on gql (version 3.5.0).

gql 3.5.0 has a range dependency on graphql-core: https://github.com/graphql-python/gql/blob/v3.5.0/setup.py#L6

```
graphql-core>=3.2,<3.3
```

Before today, we didn't have issues, because we were pulling in graphql-core 3.2.3. This change, increasing the nested levels by 2, was published today in 3.2.4: https://github.com/graphql-python/graphql-core/releases/tag/v3.2.4

graphql-core changes between 3.2.3 and 3.2.4: https://github.com/graphql-python/graphql-core/compare/v3.2.3...v3.2.4

We have some options:
1. Keep the local query validation and pin graphql-core to 3.2.3.
2. Remove the local query validation and use the latest graphql-core as before.

For now we do 2.

We could consider adding a lock file at some point.